### PR TITLE
Only lint when Dockerfile changes

### DIFF
--- a/.github/workflows/hadolint-ci.yml
+++ b/.github/workflows/hadolint-ci.yml
@@ -1,5 +1,11 @@
 name: Lint Dockerfile
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "Dockerfile"
+  pull_request:
+    paths:
+      - "Dockerfile"
 
 jobs:
   linter:


### PR DESCRIPTION
I'm not entirely certain about this, but if the linter only looks at Dockerfile, it shouldn't be run for changes to other files in the repository.